### PR TITLE
fix(lib): fixed handling of null custom fields in description mapping

### DIFF
--- a/lib/src/services/jira.ts
+++ b/lib/src/services/jira.ts
@@ -486,9 +486,9 @@ export const enhancedIssue = (
     descriptionField === undefined
       ? undefined
       : // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (issue.fields[descriptionField] as string | undefined),
+        (issue.fields[descriptionField] as string | undefined | null),
     issue.fields.description,
-  ].find((s) => s !== undefined && s.length > 0);
+  ].find((s) => s !== undefined && s !== null && s.length > 0);
 
   return {
     ...issue,
@@ -504,6 +504,6 @@ export const enhancedIssue = (
     lastWorked: lastWorked,
     quality,
     qualityReason,
-    description,
+    description: description === null ? undefined : description,
   };
 };


### PR DESCRIPTION
When reading descriptions from custom fields, the code did not correctly handle cases where the field had a value of `null`.

fix #248